### PR TITLE
fix for 'In instantiation of ‘typename boost::add_reference<T>::type …

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -296,7 +296,7 @@ Value listunspent(const Array& params, bool fHelp)
             CTxDestination address;
             if (ExtractDestination(pk, address))
             {
-                const CScriptID& hash = boost::get<const CScriptID&>(address);
+                const CScriptID& hash = boost::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))
                     entry.push_back(Pair("redeemScript", HexStr(redeemScript.begin(), redeemScript.end())));


### PR DESCRIPTION
…boost::strict_get'

This pull request will fix this error during compiling rpcrawtransaction.cpp.

`  CXX      rpcrawtransaction.o
In file included from /usr/include/boost/move/detail/type_traits.hpp:34:0,
                 from /usr/include/boost/move/core.hpp:54,
                 from /usr/include/boost/move/utility_core.hpp:29,
                 from /usr/include/boost/move/utility.hpp:28,
                 from /usr/include/boost/thread/detail/move.hpp:27,
                 from /usr/include/boost/thread/lock_types.hpp:11,
                 from /usr/include/boost/thread/pthread/mutex.hpp:16,
                 from /usr/include/boost/thread/mutex.hpp:16,
                 from allocators.h:13,
                 from serialize.h:9,
                 from bignum.h:9,
                 from chainparams.h:9,
                 from base58.h:17,
                 from rpcrawtransaction.cpp:6:
/usr/include/boost/variant/get.hpp: In instantiation of ‘typename boost::add_reference<T>::type boost::strict_get(boost::variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>&) [with U = const CScriptID&; T0 = CNoDestination; T1 = CKeyID; T2 = CScriptID; T3 = CStealthAddress; T4 = boost::detail::variant::void_; T5 = boost::detail::variant::void_; T6 = boost::detail::variant::void_; T7 = boost::detail::variant::void_; T8 = boost::detail::variant::void_; T9 = boost::detail::variant::void_; T10 = boost::detail::variant::void_; T11 = boost::detail::variant::void_; T12 = boost::detail::variant::void_; T13 = boost::detail::variant::void_; T14 = boost::detail::variant::void_; T15 = boost::detail::variant::void_; T16 = boost::detail::variant::void_; T17 = boost::detail::variant::void_; T18 = boost::detail::variant::void_; T19 = boost::detail::variant::void_; typename boost::add_reference<T>::type = const CScriptID&]’:
/usr/include/boost/variant/get.hpp:284:25:   required from ‘typename boost::add_reference<T>::type boost::get(boost::variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>&) [with U = const CScriptID&; T0 = CNoDestination; T1 = CKeyID; T2 = CScriptID; T3 = CStealthAddress; T4 = boost::detail::variant::void_; T5 = boost::detail::variant::void_; T6 = boost::detail::variant::void_; T7 = boost::detail::variant::void_; T8 = boost::detail::variant::void_; T9 = boost::detail::variant::void_; T10 = boost::detail::variant::void_; T11 = boost::detail::variant::void_; T12 = boost::detail::variant::void_; T13 = boost::detail::variant::void_; T14 = boost::detail::variant::void_; T15 = boost::detail::variant::void_; T16 = boost::detail::variant::void_; T17 = boost::detail::variant::void_; T18 = boost::detail::variant::void_; T19 = boost::detail::variant::void_; typename boost::add_reference<T>::type = const CScriptID&]’
rpcrawtransaction.cpp:299:77:   required from here
/usr/include/boost/variant/get.hpp:178:5: error: invalid application of ‘sizeof’ to incomplete type ‘boost::STATIC_ASSERTION_FAILURE<false>’
     BOOST_STATIC_ASSERT_MSG(
     ^
Makefile:897: recipe for target 'rpcrawtransaction.o' failed
make[3]: *** [rpcrawtransaction.o] Error 1
make[3]: Leaving directory '/development/hashengineering/digitalcoin-new/src'
Makefile:919: recipe for target 'all-recursive' failed
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory '/development/hashengineering/digitalcoin-new/src'
Makefile:681: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/development/hashengineering/digitalcoin-new/src'
Makefile:509: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1`